### PR TITLE
Use new CVE dataset with better embedding column

### DIFF
--- a/spicepod.yaml
+++ b/spicepod.yaml
@@ -8,17 +8,17 @@ runtime:
     zipkin_endpoint: http://zipkin.zipkin:9411/api/v2/spans
 
 datasets:
-  - from: s3://spiceai-demo-datasets/nginx/nginx_cve.csv
+  - from: s3://spiceai-demo-datasets/nginx/cve_nginx.parquet
     name: nginx.cve
     description: Security advisories and Common Vulnerabilities and Exposures (CVEs) for the Nginx project. https://nginx.org/en/security_advisories.html.
     metadata:
-      instructions: always provide reference links. use primary id as cveId, to genereate reference link.
+      instructions: Always provide reference links. Use the primary id as cveId, to generate reference links.
       reference_url_template: https://www.cve.org/CVERecord?id=<cveId>
     embeddings:
-      - column: description
+      - column: cve_data
         use: oai
         column_pk:
-         - cveId
+          - cveId
     acceleration:
       enabled: true
 
@@ -26,7 +26,7 @@ datasets:
     name: nginx.tickets
     description: Tracked issues for the Nginx project. Tickets from https://trac.nginx.org/nginx/report.
     metadata:
-      instructions: always provide reference links. use primary id as ticket_id, to genereate reference link.
+      instructions: Always provide reference links. Use the primary id as ticket_id, to generate reference links.
       reference_url_template: https://trac.nginx.org/nginx/ticket/<ticket_id>
     acceleration:
       enabled: true
@@ -56,7 +56,7 @@ datasets:
     name: nginx.commits
     description: Git commits from the Nginx project.
     metadata:
-      instructions: always provide reference links. use primary id as ticket_id, to genereate reference link.
+      instructions: Always provide reference links. Use the primary id as ticket_id, to generate reference links.
       reference_url_template: https://github.com/nginx/nginx/commit/<oid>
     embeddings:
       - column: message


### PR DESCRIPTION
## 🗣 Description

Updates the `nginx.cve` dataset to use a new Parquet file format with a JSON encoded `cve_data` field with more information.

Generated via:

```console
create table cve_nginx as select unnest(cveMetadata), to_json(containers) as cve_data from read_json_auto('**/*.json', ignore_errors = true)  where cve_data ilike '%nginx%';
create table cve_nginx2 as select * from cve_nginx where (cve_data.cna.affected->'$[*].product'->0)::text ILIKE '%nginx%';
```

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
