### PR TITLE
Update nginx.commits primary key for Github connector.

### DIFF
--- a/spicepod.yaml
+++ b/spicepod.yaml
@@ -63,12 +63,12 @@ datasets:
     description: Git commits from the Nginx project.
     metadata:
       instructions: Always provide reference links. Use the primary id as ticket_id, to generate reference links.
-      reference_url_template: https://github.com/nginx/nginx/commit/<oid>
+      reference_url_template: https://github.com/nginx/nginx/commit/<sha>
     embeddings:
       - column: message
         use: hf_minilm
         column_pk:
-          - oid
+          - sha
     acceleration:
       enabled: true
     params:


### PR DESCRIPTION
## 🗣 Description
 - Previously we used graphQL to get commits. We defined the primary key as oid. Now, with the github connector, the unique key (that also produces valid commit references), is `sha`.