### PR TITLE
`env:GITHUB_TOKEN` -> `secrets:GITHUB_TOKEN`

### DIFF
--- a/spicepod.yaml
+++ b/spicepod.yaml
@@ -72,7 +72,7 @@ datasets:
     acceleration:
       enabled: true
     params:
-      github_token: ${env:GITHUB_TOKEN}
+      github_token: ${secrets:GITHUB_TOKEN}
 
 embeddings:
   - name: oai


### PR DESCRIPTION
## 🗣 Description
 - We don't use env for spicepods in cloud
- Currently getting
```shell
2024-09-26T21:56:27.901092Z ERROR runtime::secrets: Secret 'env' referenced in ${env:GITHUB_TOKEN} not found.
```