### PR TITLE
Use zipkin service IP

### DIFF
--- a/spicepod.yaml
+++ b/spicepod.yaml
@@ -5,7 +5,7 @@ name: nginx-demo
 runtime:
   tracing:
     zipkin_enabled: true
-    zipkin_endpoint: http://zipkin.zipkin:9411/api/v2/spans
+    zipkin_endpoint: http://10.123.181.42:9411/api/v2/spans
 
 datasets:
   - from: databricks:f5_demo.default.cve_nginx


### PR DESCRIPTION
## 🗣 Description

Use the zipkin service IP instead of the internal K8s DNS name. The `kube-dns` service isn't reachable for name resolution, so I'm hard-coding the IP address instead. This IP will be stable as long as the zipkin service itself stays around.
